### PR TITLE
fix npm install errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@angular/core": "2.x",
-    "@types/core-js": "^0.9.35",
     "rxjs": "5.x",
     "typescript": "2.x",
     "zone.js": ">=0.6.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
     "compilerOptions": {
         "noImplicitAny": true,
-        "module": "commonjs",
-        "target": "ES5",
+        "module": "es6",
+        "target": "es6",
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "sourceMap": true,
-        "declaration": true
+        "declaration": true,
+        "moduleResolution": "node"
     },
     "files": [
         "index.ts"


### PR DESCRIPTION
I was trying to use this with angular 4, but was getting an error related to AOT - 
```
ERROR in Error encountered resolving symbol values statically. Calling function 'Ng2DjangoChannelsDemultiplexingModule', function calls are not supported. Consider replacing the function or lambda with a reference to an exported function, resolving symbol AppModule in xx/front-ng2/src/app/app.module.ts, resolving symbol AppModule in xx/src/app/app.module.ts`
```
I'm new to angular 4 and AOT, but these changes seem to be enough to make the AoT compiler shut up.

Thank you very much for creating this by the way - very useful! 👍 